### PR TITLE
Enable extend for background faces

### DIFF
--- a/highlight-doxygen.el
+++ b/highlight-doxygen.el
@@ -263,15 +263,15 @@
 
 
 (defface highlight-doxygen-comment
-  '((((background light)) :inherit font-lock-doc-face :background "grey95")
-    (((background dark))  :inherit font-lock-doc-face :background "grey30"))
+  '((((background light)) :inherit font-lock-doc-face :background "grey95" :extend t)
+    (((background dark))  :inherit font-lock-doc-face :background "grey30" :extend t))
   "The face used for Doxygen comment blocks."
   :group 'highlight-doxygen)
 
 
 (defface highlight-doxygen-code-block
-  '((((background light)) :background "grey85")
-    (((background dark))  :background "grey40"))
+  '((((background light)) :background "grey85" :extend t)
+    (((background dark))  :background "grey40" :extend t))
   "The face used to mark a code block."
   :group 'highlight-doxygen)
 


### PR DESCRIPTION
In Emacs 27 or newer, this setting adds less visual noise.

See before/after example.
![before_after](https://user-images.githubusercontent.com/1869379/149231823-1c368e21-9911-4544-b17b-fc83b9772868.jpg)

